### PR TITLE
Modify mongo middleware

### DIFF
--- a/controllers/mongo.js
+++ b/controllers/mongo.js
@@ -29,7 +29,7 @@ export async function connectToDatabase() {
 
 // Function to close the database connection
 export async function closeDatabaseConnection() {
+  console.log("Mongoose connection closing.");
   // Close the Mongoose connection
   await mongoose.connection.close();
-  console.log("Mongoose connection closed.");
 }

--- a/middleware/mongoConnection.js
+++ b/middleware/mongoConnection.js
@@ -1,22 +1,25 @@
+import consoleStamp from "console-stamp";
 import {
   connectToDatabase,
   closeDatabaseConnection,
 } from "../controllers/mongo.js";
 
 // Create a middleware function to close the Mongoose connection
-export const closeMongooseConnection = (req, res, next) => {
-  // Close the Mongoose connection
-  closeDatabaseConnection();
+export const closeMongooseConnection = () => {
+  // action after response
+  var afterResponse = function () {
+    // any other clean ups
+    closeDatabaseConnection().then(() => {
+      console.log("Closed mongodb connection.");
+    });
+  };
 
-  // Continue to the next middleware or route handler
-  next();
+  // hooks to execute after response
+  process.on("exit", afterResponse);
 };
 
 // Middleware to connect to the database
-export const cerateMongooseConnection = async (req, res, next) => {
+export const createMongooseConnection = async () => {
   // Establish a Mongoose connection
   await connectToDatabase();
-
-  // Continue to next route
-  next();
 };

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ import { cache_router } from "./routes/cache.js";
 
 // MIDDLEWARE
 import {
-  cerateMongooseConnection,
+  createMongooseConnection,
   closeMongooseConnection,
 } from "./middleware/mongoConnection.js";
 import { handleCors } from "./middleware/cors.js";
@@ -25,9 +25,6 @@ app.use(handleCors);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
-// Middleware to connect to MongoDB when the server starts
-app.use(cerateMongooseConnection);
-
 // Add routes for fetch
 app.use("/api/fetch", fetch_router);
 
@@ -40,9 +37,9 @@ app.use("/api/search", search_router);
 // Add routes for cached reviews
 app.use("/api/cache", cache_router);
 
-// Use the middleware to automatically close the connection
-app.use(closeMongooseConnection);
-
 app.listen(3000, () => {
+  createMongooseConnection();
   console.log("Server listening on port 3000");
+  // create process listener to close connection on exit
+  closeMongooseConnection();
 });


### PR DESCRIPTION
Change mongo middleware to create connection on server start. This is instead of creating connection for each api event. Listener that closes connection on exit.
